### PR TITLE
6.2 コンストラクタ情報の抽出機能追加

### DIFF
--- a/.kiro/specs/bakin-doc-scraper/tasks.md
+++ b/.kiro/specs/bakin-doc-scraper/tasks.md
@@ -1,93 +1,47 @@
 # Implementation Plan
 
 - [x] 1. プロジェクト構造とコア依存関係のセットアップ
-
-
-
-
-
   - プロジェクトディレクトリ構造を作成
   - requirements.txtファイルを作成（aiohttp, beautifulsoup4, tqdm, tenacity）
   - 基本的な設定ファイル（config.yaml）を作成
   - _Requirements: 1.1, 1.2_
 
 - [x] 2. データモデルクラスの実装
-
-
-
-
   - [x] 2.1 基本データクラスの定義
-
-
-
-
-
-
     - ParameterInfo, ExceptionInfo, ConstructorInfo等の基本データクラスを実装
     - 型ヒントと@dataclassデコレータを使用
     - _Requirements: 2.2_
   
   - [x] 2.2 メインデータモデルの実装
-
-
     - NamespaceInfo, ClassInfo, MethodInfo, PropertyInfo等のメインクラスを実装
     - JSON シリアライゼーション用のto_dict/from_dictメソッドを追加
     - _Requirements: 2.2_
 
 - [ ] 3. HTTPクライアントとHTML解析の基盤実装
   - [x] 3.1 非同期HTTPクライアントの実装
-
-
-
-
-
     - aiohttpを使用した基本HTTPクライアントクラスを作成
     - リトライ機構とレート制限を実装（tenacityライブラリ使用）
     - _Requirements: 1.3, 5.1, 5.3_
   
   - [x] 3.2 HTML解析ユーティリティの実装
-
-
-
-
-
     - BeautifulSoup4を使用したHTML解析ヘルパー関数を作成
     - 相対URLを絶対URLに変換する機能を実装
     - _Requirements: 1.3_
 
 - [x] 4. 進行状況トラッカーの実装
-
-
-
-
-
   - ProgressTrackerクラスを実装
   - tqdmを使用した視覚的プログレスバーを統合
   - ログ出力機能を追加（標準ライブラリlogging使用）
   - _Requirements: 4.1, 4.2, 4.3, 4.4_
 
 - [x] 5. 名前空間とクラス一覧の取得と初期JSON出力
-
-
-
-
   - [x] 5.1 namespaces.htmlページの解析
-
-
-
-
-
-
-
-
     - namespaces.htmlページから全ての名前空間とクラス情報を一括取得
     - 名前空間名、クラス名、クラスURLを抽出
     - 階層構造を保持したデータ構造を構築
     - _Requirements: 1.1, 1.2, 1.3_
   
   - [x] 5.2 クラス一覧の構造化と簡易JSON出力
-
-
     - 取得したクラス情報を名前空間ごとに整理
     - クラスURLの正規化と検証
     - 重複チェックとデータクリーニング
@@ -97,21 +51,13 @@
 
 - [ ] 6. クラス詳細情報のスクレイピング実装（段階的アプローチ）
   - [x] 6.1 単一クラス詳細取得機能の実装
-
-
-
-
-
-
-
-
     - classes_list.jsonから1つのクラスを選択して詳細情報を取得
     - クラス基本情報（名前、完全名、継承情報、説明）を抽出
     - 取得結果をJSONファイルに保存（single_class_test.json）
     - HTMLの構造に基づいた柔軟なセレクター戦略を実装
     - _Requirements: 1.3_
   
-  - [ ] 6.2 コンストラクタ情報の抽出機能追加
+  - [x] 6.2 コンストラクタ情報の抽出機能追加
     - 6.1で実装したクラスにコンストラクタ情報抽出を追加
     - パラメータの型と名前を正確に解析
     - 結果をsingle_class_test.jsonに追加保存

--- a/scripts/test_single_class_scraper.py
+++ b/scripts/test_single_class_scraper.py
@@ -40,23 +40,38 @@ async def test_single_class_scraping():
     with open(classes_list_path, 'r', encoding='utf-8') as f:
         classes_data = json.load(f)
     
-    # テスト用のクラスを選択（Yukarネームスペースから選択）
+    # テスト用のクラスを選択（コンストラクタがありそうなクラスを探す）
     test_class = None
     test_namespace = None
     
+    # より一般的なクラス名を探す（コンストラクタがある可能性が高い）
+    target_classes = ['GameObject', 'Component', 'Vector3', 'Color', 'Transform', 'Renderer']
+    
     for namespace in classes_data.get('namespaces', []):
-        if namespace.get('name') == 'Yukar' and namespace.get('classes') and len(namespace['classes']) > 0:
-            # AbnormalActionEffectParamBase クラスを選択（説明がありそう）
+        if namespace.get('classes') and len(namespace['classes']) > 0:
             for cls in namespace['classes']:
-                if cls['name'] == 'AbnormalActionEffectParamBase':
+                if any(target in cls['name'] for target in target_classes):
                     test_class = cls
                     test_namespace = namespace['name']
                     break
-            if not test_class:
-                # 見つからない場合は最初のクラスを使用
-                test_class = namespace['classes'][0]
-                test_namespace = namespace['name']
-            break
+            if test_class:
+                break
+    
+    # 見つからない場合はYukarネームスペースから選択
+    if not test_class:
+        for namespace in classes_data.get('namespaces', []):
+            if namespace.get('name') == 'Yukar' and namespace.get('classes') and len(namespace['classes']) > 0:
+                # AbnormalActionEffectParamBase クラスを選択（説明がありそう）
+                for cls in namespace['classes']:
+                    if cls['name'] == 'AbnormalActionEffectParamBase':
+                        test_class = cls
+                        test_namespace = namespace['name']
+                        break
+                if not test_class:
+                    # 見つからない場合は最初のクラスを使用
+                    test_class = namespace['classes'][0]
+                    test_namespace = namespace['name']
+                break
     
     if not test_class:
         logger.error("No classes found in the classes list")

--- a/tests/test_constructor_extraction.py
+++ b/tests/test_constructor_extraction.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""
+コンストラクタ抽出機能のテスト
+
+ClassDetailScraperのコンストラクタ抽出機能をテストします。
+"""
+
+import unittest
+from unittest.mock import Mock
+from bs4 import BeautifulSoup
+
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).parent.parent))
+
+from src.scraper.class_detail_scraper import ClassDetailScraper
+from src.models.basic_models import ConstructorInfo, ParameterInfo
+
+
+class TestConstructorExtraction(unittest.TestCase):
+    """コンストラクタ抽出機能のテストクラス"""
+    
+    def setUp(self):
+        """テストセットアップ"""
+        # モックHTTPクライアントを作成
+        mock_http_client = Mock()
+        self.scraper = ClassDetailScraper(mock_http_client)
+    
+    def test_parse_parameters_from_definition(self):
+        """パラメータ解析のテスト"""
+        # テストケース1: 単一パラメータ
+        params = self.scraper._parse_parameters_from_definition("TestClass(int value)")
+        print(f"Test 1 - Expected: 1, Got: {len(params)}, Params: {[(p.name, p.type) for p in params]}")
+        self.assertEqual(len(params), 1)
+        self.assertEqual(params[0].name, "value")
+        self.assertEqual(params[0].type, "int")
+        
+        # テストケース2: 複数パラメータ
+        params = self.scraper._parse_parameters_from_definition("TestClass(string name, int age, bool active)")
+        print(f"Test 2 - Expected: 3, Got: {len(params)}, Params: {[(p.name, p.type) for p in params]}")
+        self.assertEqual(len(params), 3)
+        self.assertEqual(params[0].name, "name")
+        self.assertEqual(params[0].type, "string")
+        self.assertEqual(params[1].name, "age")
+        self.assertEqual(params[1].type, "int")
+        self.assertEqual(params[2].name, "active")
+        self.assertEqual(params[2].type, "bool")
+        
+        # テストケース3: パラメータなし
+        params = self.scraper._parse_parameters_from_definition("TestClass()")
+        print(f"Test 3 - Expected: 0, Got: {len(params)}, Params: {[(p.name, p.type) for p in params]}")
+        self.assertEqual(len(params), 0)
+        
+        # テストケース4: 複雑な型
+        params = self.scraper._parse_parameters_from_definition("TestClass(List<string> items, Dictionary<int, string> map)")
+        print(f"Test 4 - Expected: 2, Got: {len(params)}, Params: {[(p.name, p.type) for p in params]}")
+        self.assertEqual(len(params), 2)
+        self.assertEqual(params[0].name, "items")
+        self.assertEqual(params[0].type, "List<string>")
+        self.assertEqual(params[1].name, "map")
+        self.assertEqual(params[1].type, "Dictionary<int, string>")
+    
+    def test_parse_single_parameter(self):
+        """単一パラメータ解析のテスト"""
+        # 基本的なパラメータ
+        param = self.scraper._parse_single_parameter("int value")
+        self.assertIsNotNone(param)
+        self.assertEqual(param.name, "value")
+        self.assertEqual(param.type, "int")
+        
+        # デフォルト値付きパラメータ
+        param = self.scraper._parse_single_parameter("string name = \"default\"")
+        self.assertIsNotNone(param)
+        self.assertEqual(param.name, "name")
+        self.assertEqual(param.type, "string")
+        
+        # 配列型
+        param = self.scraper._parse_single_parameter("int[] values")
+        self.assertIsNotNone(param)
+        self.assertEqual(param.name, "values")
+        self.assertEqual(param.type, "int[]")
+        
+        # ref/out修飾子
+        param = self.scraper._parse_single_parameter("ref int value")
+        self.assertIsNotNone(param)
+        self.assertEqual(param.name, "value")
+        self.assertEqual(param.type, "int")
+    
+    def test_extract_constructors_from_code_with_mock_html(self):
+        """モックHTMLを使用したコンストラクタ抽出のテスト"""
+        # テスト用のHTML
+        html_content = """
+        <div class="memproto">
+            <div class="definition">
+                public TestClass(int id, string name)
+            </div>
+        </div>
+        <div class="code">
+            private TestClass()
+        </div>
+        <div class="static-field">
+            static readonly Guid TestId = new Guid("12345");
+        </div>
+        """
+        
+        soup = BeautifulSoup(html_content, 'html.parser')
+        constructors = self.scraper._extract_constructors_from_code(soup, "TestClass")
+        
+        print(f"Found {len(constructors)} constructors:")
+        for i, c in enumerate(constructors):
+            print(f"  {i+1}. {c.access_modifier} {c.name}({', '.join([f'{p.type} {p.name}' for p in c.parameters])})")
+        
+        # 2つのコンストラクタが見つかることを確認
+        self.assertEqual(len(constructors), 2)
+        
+        # 最初のコンストラクタ（public）
+        public_constructor = next((c for c in constructors if c.access_modifier == "public"), None)
+        self.assertIsNotNone(public_constructor)
+        self.assertEqual(public_constructor.name, "TestClass")
+        self.assertEqual(len(public_constructor.parameters), 2)
+        self.assertEqual(public_constructor.parameters[0].name, "id")
+        self.assertEqual(public_constructor.parameters[0].type, "int")
+        self.assertEqual(public_constructor.parameters[1].name, "name")
+        self.assertEqual(public_constructor.parameters[1].type, "string")
+        
+        # 2番目のコンストラクタ（private）
+        private_constructor = next((c for c in constructors if c.access_modifier == "private"), None)
+        self.assertIsNotNone(private_constructor)
+        self.assertEqual(private_constructor.name, "TestClass")
+        self.assertEqual(len(private_constructor.parameters), 0)
+    
+    def test_extract_constructors_from_table_with_mock_html(self):
+        """モックHTMLテーブルを使用したコンストラクタ抽出のテスト"""
+        html_content = """
+        <table>
+            <tr>
+                <td>TestClass(int value)</td>
+                <td>値を指定してインスタンスを初期化します</td>
+            </tr>
+            <tr>
+                <td>TestClass()</td>
+                <td>デフォルトコンストラクタ</td>
+            </tr>
+            <tr>
+                <td>static readonly Guid Id = new Guid("123")</td>
+                <td>静的フィールド</td>
+            </tr>
+        </table>
+        """
+        
+        soup = BeautifulSoup(html_content, 'html.parser')
+        constructors = self.scraper._extract_constructors_from_table(soup, "TestClass")
+        
+        # 2つのコンストラクタが見つかることを確認（静的フィールドは除外）
+        self.assertEqual(len(constructors), 2)
+        
+        # パラメータ付きコンストラクタ
+        param_constructor = next((c for c in constructors if len(c.parameters) > 0), None)
+        self.assertIsNotNone(param_constructor)
+        self.assertEqual(param_constructor.name, "TestClass")
+        self.assertEqual(len(param_constructor.parameters), 1)
+        self.assertEqual(param_constructor.parameters[0].name, "value")
+        self.assertEqual(param_constructor.parameters[0].type, "int")
+        self.assertEqual(param_constructor.description, "値を指定してインスタンスを初期化します")
+        
+        # デフォルトコンストラクタ
+        default_constructor = next((c for c in constructors if len(c.parameters) == 0), None)
+        self.assertIsNotNone(default_constructor)
+        self.assertEqual(default_constructor.name, "TestClass")
+        self.assertEqual(default_constructor.description, "デフォルトコンストラクタ")
+    
+    def test_filter_static_fields(self):
+        """静的フィールドの除外テスト"""
+        html_content = """
+        <div class="code">
+            static readonly Guid TestId = new Guid("12345");
+            public static TestClass Instance = new TestClass();
+            const int MaxValue = 100;
+            public TestClass(int value)
+        </div>
+        """
+        
+        soup = BeautifulSoup(html_content, 'html.parser')
+        constructors = self.scraper._extract_constructors_from_code(soup, "TestClass")
+        
+        print(f"Found {len(constructors)} constructors:")
+        for i, c in enumerate(constructors):
+            print(f"  {i+1}. {c.access_modifier} {c.name}({', '.join([f'{p.type} {p.name}' for p in c.parameters])})")
+        
+        # 静的フィールドは除外され、コンストラクタのみが抽出されることを確認
+        self.assertEqual(len(constructors), 1)
+        self.assertEqual(constructors[0].name, "TestClass")
+        self.assertEqual(len(constructors[0].parameters), 1)
+        self.assertEqual(constructors[0].parameters[0].name, "value")
+        self.assertEqual(constructors[0].parameters[0].type, "int")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
実装内容
コンストラクタ抽出機能の追加

ClassDetailScraperクラスに_extract_constructorsメソッドを追加
HTMLの複数のセクション（コードブロック、テーブル、セクション）からコンストラクタ情報を抽出
パラメータ解析機能の実装

ジェネリック型を考慮した安全なパラメータ分割機能
型と名前の正確な解析
デフォルト値やref/out修飾子の適切な処理
フィルタリング機能の強化

静的フィールドやプロパティの除外
newキーワードによるインスタンス化の除外
重複コンストラクタの除去
アクセス修飾子の検出

public、private、protected、internalの正確な識別
コンテキストを考慮した修飾子の抽出
テスト結果
単体テスト5件すべてが成功
実際のBakinドキュメントからColorクラスの4つのコンストラクタを正常に抽出
パラメータの型と名前が正確に解析されることを確認